### PR TITLE
FIX: handle when users table doesn't exist yet

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -49,18 +49,22 @@ after_initialize do
     </noscript>
     EOS
 
-  if User.exists?
-    sitepoint_site_customization = SiteCustomization.find_or_create_by({
-      name: "SitePoint Crawler links",
-      header: header,
-      mobile_header: header,
-      enabled: true,
-      user_id: User.first.id,
-    })
-    # cleanup old customizations
-    SiteCustomization.where(name: sitepoint_site_customization.name).
-      where.not(id: sitepoint_site_customization.id).
-      delete_all
+  begin
+    if User.exists?
+      sitepoint_site_customization = SiteCustomization.find_or_create_by({
+        name: "SitePoint Crawler links",
+        header: header,
+        mobile_header: header,
+        enabled: true,
+        user_id: User.first.id,
+      })
+      # cleanup old customizations
+      SiteCustomization.where(name: sitepoint_site_customization.name).
+        where.not(id: sitepoint_site_customization.id).
+        delete_all
+    end
+  rescue ActiveRecord::StatementInvalid
+    # This happens when you run db:migrate on a database that doesn't have any tables yet.
   end
 end
 


### PR DESCRIPTION
The plugin is preventing a new db from being provisioned because the users table doesn't exist yet. I made a fix in Discourse for this case, but your fork doesn't have it. So this fix should handle it in your plugin. :smiley: 



