### PR TITLE
Refactor from awesome-bar to SpHelloBar

### DIFF
--- a/assets/javascripts/discourse/initializers/random-hello-bar.js.es6
+++ b/assets/javascripts/discourse/initializers/random-hello-bar.js.es6
@@ -1,162 +1,33 @@
+import SpHelloBar                    from '../../spHelloBar/SpHelloBar';
+import getRandomContent              from '../../spHelloBar/getRandomContent';
+import { checkForCookie, setCookie } from '../../spHelloBar/cookieManager';
+import trackEvent                    from '../../spHelloBar/trackEvent';
+
 export default {
   name: 'random-hello-bar',
   initialize() {
-
-
     (function(window, $) {
-      "use strict";
 
-      var EXPIRE_DAYS = 14;
+      if ($('html').hasClass('mobile-device')) return;
 
-      var RandomHelloBar = function() {
+      const sph = new SpHelloBar();
 
-        var isEnabled = true;
+      // extend SpHelloBar
+      sph.after('beforeInit', function() {
+        checkForCookie.call(sph);
+      });
+      sph.after('onClose', function() {
+        setCookie.call(sph);
+      });
+      sph.after('onClick', function() {
+        trackEvent.call(sph, 'Click');
+      });
+      sph.after('onToggle', function() {
+        trackEvent.call(sph, 'Impression');
+      });
 
-        // if jQuery Cookie is available, we may have disabled ourselves for the number of days set in EXPIRE_DAYS if user manually closed the bar
-        if ($.cookie) {
-          if ($.cookie('awesomeBarDisabled')) {
-            isEnabled = false;
-          }
-        }
-
-        if ($('html').hasClass('mobile-device')) isEnabled = false;
-
-        isEnabled && this.getAd();
-      };
-
-      RandomHelloBar.prototype = {
-
-        init: function() {
-          var className = '.awesome-bar';
-          if(!$(className).length) return;
-
-          this.$el               = $(className);
-          this.$closeBtn         = this.$el.find('.awesome-bar_close');
-          this.isShown           = false;
-          this.targetOffset      = 300;
-          this.impressionTracked = false;
-
-          this.checkPosition   = this._throttle($.proxy(this.checkPosition, this), 500);
-          this.closeBtnHandler = $.proxy(this.closeBtnHandler, this);
-
-          this.$el.addClass('js');
-          this.bindEvents();
-        },
-
-        bindEvents: function() {
-          var that = this;
-
-          $(window).on('scroll', this.checkPosition);
-
-          this.$el.on('click', 'a', function() {
-            that.trackEvent('Click');
-          });
-
-          this.$closeBtn.on('click', this.closeBtnHandler);
-        },
-
-        unBindEvents: function () {
-          $(window).off('scroll', this.checkPosition);
-        },
-
-        checkPosition: function() {
-          var windowTop = window.pageYOffset || document.documentElement.scrollTop;
-
-          if( !this.isShown && (windowTop > this.targetOffset) ) {
-            this.showBar(true);
-          } else if (this.isShown && (windowTop < this.targetOffset)) {
-            this.showBar(false);
-          }
-        },
-
-        showBar: function( shouldBeShown ) {
-          this.$el.toggleClass('show', shouldBeShown);
-          if( shouldBeShown && !this.impressionTracked ) {
-            this.impressionTracked = true;
-            this.trackEvent('Impression');
-          }
-          this.isShown = shouldBeShown;
-        },
-
-        trackEvent: function(label) {
-          if(typeof(ga)=='undefined') return;
-          var campaignName = this.$el.attr('data-campaign') || 'unnamed_campaign';
-          ga('send', 'event', 'Awesome Bar', campaignName, label, {'nonInteraction': true});
-        },
-
-        closeBtnHandler: function (evt) {
-          this.showBar(false);
-          this.unBindEvents();
-          $.cookie && $.cookie('awesomeBarDisabled', 'truthy', { path: '/', expires: EXPIRE_DAYS } );
-        },
-
-        // taken from
-        //
-        // Underscore.js 1.5.2
-        // http://underscorejs.org
-        // (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
-        // Underscore may be freely distributed under the MIT license.
-        //
-        // Returns a function, that, when invoked, will only be triggered at most once
-        // during a given window of time.
-        _throttle: function(func, wait) {
-          var context, args, timeout, result;
-          var previous = 0;
-          var later = function() {
-            previous = new Date();
-            timeout  = null;
-            result   = func.apply(context, args);
-          };
-          return function() {
-            var now       = new Date();
-            var remaining = wait - (now - previous);
-            context       = this;
-            args          = arguments;
-            if (remaining <= 0) {
-              clearTimeout(timeout);
-              timeout  = null;
-              previous = now;
-              result   = func.apply(context, args);
-            } else if (!timeout) {
-              timeout = setTimeout(later, remaining);
-            }
-            return result;
-          };
-        },
-
-        getAd: function() {
-          var that = this;
-          jQuery.ajax({
-            type: 'POST',
-            url: 'http://www.sitepoint.com/wp-admin/admin-ajax.php',
-            data: {
-              action: 'get_forums_random_hello_bar',
-              rand: Math.random()
-            },
-            success: function(data, textStatus, XMLHttpRequest) {
-              $("body").prepend(data);
-              that.init();
-            }
-          });
-        }
-
-      };
-
-      // FIXME: hack: waiting for $/foundation.cookie to become ready for some time before going cookieless
-      var iterations = 0,
-          instantiate = function () {
-            if (($ && $.cookie) || iterations > 10) {
-              window.RandomHelloBar = new RandomHelloBar();
-            } else {
-              iterations++;
-              setTimeout(instantiate, 500);
-            }
-          };
-
-      instantiate();
+     getRandomContent(() => sph.init());
 
     })(window, (typeof jQuery !== "undefined") ? jQuery : Zepto);
-
-
   }
 };

--- a/assets/javascripts/spHelloBar/SpHelloBar.js.es6
+++ b/assets/javascripts/spHelloBar/SpHelloBar.js.es6
@@ -1,0 +1,127 @@
+import throttle from './throttle';
+
+function SpHelloBar({
+    isEnabled        = true,
+    isShown          = false,
+    shouldBeShown    = false,
+    targetOffset     = 300,
+    throttleWait     = 500,
+    elSelector       = '.SpHelloBar',
+    closeBtnSelector = '.SpHelloBar_close',
+    linkSelector     = '.SpHelloBar_container',
+    showClassName    = 'SpHelloBar u-show',
+    hideClassName    = 'SpHelloBar'
+  } = {}){
+  this.isEnabled        = isEnabled;
+  this.isShown          = isShown;
+  this.shouldBeShown    = shouldBeShown;
+  this.targetOffset     = targetOffset;
+  this.throttleWait     = throttleWait;
+  this.elSelector       = elSelector;
+  this.closeBtnSelector = closeBtnSelector;
+  this.linkSelector     = linkSelector;
+  this.showClassName    = showClassName;
+  this.hideClassName    = hideClassName;
+}
+
+SpHelloBar.prototype = {
+  beforeInit: function beforeInit() {
+    this.checkForThrottle();
+    this.checkForEl();
+  },
+
+  onInit: function onInit() {
+    this.findCloseBtn();
+    this.findLink();
+  },
+
+  onScroll: function onScroll() {
+    this.checkPosition();
+    this.checkForVisChange();
+  },
+
+  onToggle: function onToggle() {
+    this.isShown = this.shouldBeShown;
+    this.toggleClass();
+  },
+
+  onClick: function onClick() {
+    // noop by default
+  },
+
+  onClose: function onClose(e) {
+    e.preventDefault();
+    this.unBindEvents();
+    this.shouldBeShown = false;
+    this.onToggle();
+  },
+
+  init: function init() {
+    this.beforeInit();
+    if(!this.isEnabled) return;
+
+    this.onInit();
+
+    this.checkPositionThrottled =  throttle(
+      this.onScroll.bind(this),
+      this.throttleWait
+    );
+
+    this.bindEvents();
+  },
+
+  findCloseBtn: function findCloseBtn() {
+    this.$closeBtn = this.$el.querySelector(this.closeBtnSelector);
+    this.$closeBtn && this.$closeBtn.addEventListener('click', this.onClose.bind(this));
+  },
+
+  findLink: function findLink() {
+    this.$link = this.$el.querySelector(this.linkSelector);
+    this.$link && this.$link.addEventListener('click', this.onClick.bind(this));
+  },
+
+  bindEvents: function bindEvents() {
+    window.addEventListener('scroll', this.checkPositionThrottled);
+    window.addEventListener('resize', this.checkPositionThrottled);
+  },
+
+  unBindEvents: function unBindEvents() {
+    window.removeEventListener('scroll', this.checkPositionThrottled);
+    window.removeEventListener('resize', this.checkPositionThrottled);
+  },
+
+  toggleClass: function toggleClass() {
+    this.$el.className = (this.isShown) ? this.showClassName : this.hideClassName ;
+  },
+
+  checkForVisChange: function checkForVisChange() {
+    if(this.shouldBeShown == this.isShown) return;
+    this.onToggle();
+  },
+
+  checkPosition: function checkPosition() {
+    const windowTop = window.pageYOffset || document.documentElement.scrollTop;
+    this.shouldBeShown = (windowTop > this.targetOffset);
+  },
+
+  checkForThrottle: function checkForThrottle() {
+    this.isEnabled = this.isEnabled && !!throttle;
+    !this.isEnabled && console.log('umm I need a throttle');
+  },
+
+  checkForEl: function checkForEl() {
+    this.$el = document.querySelector(this.elSelector);
+    this.isEnabled = this.isEnabled && !!this.$el;
+    !this.isEnabled && console.log('umm I need some DOM');
+  },
+
+  after: function after (method, fn) {
+    const oldMethod = this[method];
+    this[method] = function() {
+      oldMethod.apply(this, arguments);
+      fn.apply(this, arguments);
+    }
+  }
+}
+
+export default SpHelloBar;

--- a/assets/javascripts/spHelloBar/cookieManager.js.es6
+++ b/assets/javascripts/spHelloBar/cookieManager.js.es6
@@ -1,0 +1,15 @@
+const EXPIRE_DAYS = 14;
+
+export function checkForCookie () {
+  // if jQuery Cookie is available, we may have disabled ourselves for the number of days set in EXPIRE_DAYS if user manually closed the bar
+  if (typeof($)!='undefined' && $.cookie && $.cookie('SpHelloBarDisabled')) {
+    this.isEnabled = false;
+  }
+}
+
+export function setCookie () {
+  typeof($)!='undefined' && $.cookie && $.cookie('SpHelloBarDisabled', 'truthy', {
+    path: '/',
+    expires: EXPIRE_DAYS
+  });
+}

--- a/assets/javascripts/spHelloBar/getRandomContent.js.es6
+++ b/assets/javascripts/spHelloBar/getRandomContent.js.es6
@@ -1,0 +1,16 @@
+export default function (cb) {
+  const host = (window.location.host == 'discourse.vm') ? 'blog.vm' : 'www.sitepoint.com';
+
+  $.ajax({
+    type: 'POST',
+    url: `http://${host}/wp-admin/admin-ajax.php`,
+    data: {
+      action: 'get_forums_random_hello_bar',
+      rand: Math.random()
+    },
+    success: function(data, textStatus, XMLHttpRequest) {
+      $("body").prepend(data);
+      cb();
+    }
+  });
+}

--- a/assets/javascripts/spHelloBar/throttle.js.es6
+++ b/assets/javascripts/spHelloBar/throttle.js.es6
@@ -1,0 +1,34 @@
+
+// taken from
+//
+// Underscore.js 1.5.2
+// http://underscorejs.org
+// (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+// Underscore may be freely distributed under the MIT license.
+//
+// Returns a function, that, when invoked, will only be triggered at most once
+// during a given window of time.
+export default function(func, wait) {
+  var context, args, timeout, result;
+  var previous = 0;
+  var later = function() {
+    previous = new Date();
+    timeout  = null;
+    result   = func.apply(context, args);
+  };
+  return function() {
+    var now       = new Date();
+    var remaining = wait - (now - previous);
+    context       = this;
+    args          = arguments;
+    if (remaining <= 0) {
+      clearTimeout(timeout);
+      timeout  = null;
+      previous = now;
+      result   = func.apply(context, args);
+    } else if (!timeout) {
+      timeout = setTimeout(later, remaining);
+    }
+    return result;
+  };
+}

--- a/assets/javascripts/spHelloBar/trackEvent.js.es6
+++ b/assets/javascripts/spHelloBar/trackEvent.js.es6
@@ -1,0 +1,14 @@
+export default function trackEvent (label) {
+  if (!this.impressionTracked && this.isShown && label == 'Impression') {
+    this.impressionTracked = true;
+  } else if(this.isShown && label == 'Impression') {
+    return;
+  }
+
+  if (typeof(ga) == 'undefined') return;
+
+  const campaignName = this.$el.getAttribute('data-campaign') || 'unnamed_campaign';
+  ga('send', 'event', 'SP Hello Bar', campaignName, label, {
+    'nonInteraction': true
+  });
+}

--- a/assets/stylesheets/sp-hello-bar.scss
+++ b/assets/stylesheets/sp-hello-bar.scss
@@ -1,4 +1,4 @@
-.awesome-bar {
+.SpHelloBar {
   -webkit-transition: top 800ms;
   -moz-transition: top 800ms;
   -o-transition: top 800ms;
@@ -17,7 +17,7 @@
     color:#fff;
   }
 
-  &.show {
+  &.u-show {
     top: 63px;
     -webkit-backface-visibility: hidden;
     -webkit-transform: translateZ(0);
@@ -26,7 +26,7 @@
   }
 }
 
-.awesome-bar_container {
+.SpHelloBar_container {
   margin: 0 50px;
   max-width: 80em;
   display: block;
@@ -35,24 +35,18 @@
   @media (max-width: 680px) {
     text-align: center;
   }
-
-  * {
-    display: inline-block;
-    margin-bottom:0;
-    vertical-align: middle;
-  }
 }
 
-.awesome-bar_container:before, .awesome-bar_container:after {
+.SpHelloBar_container:before, .SpHelloBar_container:after {
   content: " ";
   display: table;
 }
 
-.awesome-bar_container:after {
+.SpHelloBar_container:after {
   clear: both;
 }
 
-.awesome-bar_brand {
+.SpHelloBar_brand {
   float: left;
   margin: 3px 0 0 0;
 
@@ -61,7 +55,7 @@
   }
 }
 
-.awesome-bar_message {
+.SpHelloBar_message {
   font-weight: 700;
   float: left;
   line-height: 1;
@@ -73,26 +67,20 @@
   }
 }
 
-.awesome-bar_action {
+.SpHelloBar_action {
   background:lighten(#1c94c6, 15%);
   float:right;
   margin-bottom:0;
-
   -webkit-border-radius: 2px;
   border-radius: 2px;
-  padding-top: 0.625em;
-  padding-bottom: 0.5625em;
   -webkit-appearance: none;
-  padding-right: 1.125em;
-  padding-left: 1.125em;
+  padding: 0.6em 1.1em;
   font-size: 0.8125em;
   text-transform: capitalize;
-  border-style: solid;
-  border-width: 0;
   font-weight: 700;
   line-height: 1;
   text-decoration: none;
-  border-color: #1779a2;
+  border: solid 0 #1779a2;
   color: #fff;
 
   @media (max-width: 680px) {
@@ -102,18 +90,22 @@
   }
 }
 
-.awesome-bar_close {
+.SpHelloBar_close {
   color: #fff;
   cursor: pointer;
   display: block;
+  position: absolute;
   font-size: 13px;
   height: 20px;
+  width: 20px;
   padding-top: 2px;
-  position: absolute;
+  top: 16px;
   right: 11px;
   text-align: center;
-  top: 16px;
-  width: 20px;
+
+  &:visited {
+    color: #fff;
+  }
 
   &:hover {
     -webkit-border-radius: 50%;

--- a/plugin.rb
+++ b/plugin.rb
@@ -185,8 +185,8 @@ register_asset "stylesheets/desktop/topic.scss", :desktop
 #  font for staff-counters
 register_asset "stylesheets/desktop/user.scss", :desktop
 
-#### Random Hello Bar
-register_asset "stylesheets/random-hello-bar.scss"
+#### SP Hello Bar
+register_asset "stylesheets/sp-hello-bar.scss"
 
 #### Component: PM Button
 #  NOTE: [JB] some serious round robin shit going on here. serious wtf...


### PR DESCRIPTION
Refactors SpHelloBar into a reusable script without JS or CSS dependencies (other than a throttle function)

- SpHelloBar.js is designed to be a reusable and extendable base that could be used on any site
- cookieManager.js, getRandomContent.js and trackEvent.js are used as mixins extending the basic SpHelloBar
  - as they are specific to this site they make use of jquery for ajax and cookies
  - they could easily be refactored to use other libs (without touching SpHelloBar.js) if jQuery was not available

<img width="1130" alt="screen shot 2015-09-18 at 9 22 41 am" src="https://cloud.githubusercontent.com/assets/1479712/9949011/0c2bc914-5dec-11e5-90d4-e702cffa04fb.png">
<img width="920" alt="screen shot 2015-09-18 at 9 23 09 am" src="https://cloud.githubusercontent.com/assets/1479712/9949009/0c276022-5dec-11e5-86b1-09a33d85a193.png">
<img width="656" alt="screen shot 2015-09-18 at 9 32 49 am" src="https://cloud.githubusercontent.com/assets/1479712/9949010/0c28f5cc-5dec-11e5-8637-de27eefe3c68.png">

WP Admin
<img width="743" alt="screen shot 2015-09-18 at 10 00 46 am" src="https://cloud.githubusercontent.com/assets/1479712/9949026/37fa06d2-5dec-11e5-860f-eb2c09b276aa.png">
