### PR TITLE
Remove avatar logic from stylesheets

### DIFF
--- a/assets/stylesheets/desktop/discourse.scss
+++ b/assets/stylesheets/desktop/discourse.scss
@@ -1,15 +1,3 @@
 @import "common/foundation/variables";
 @import "common/foundation/mixins";
 @import "common/foundation/helpers";
-
-.avatar {
-  @include border-radius-all(0);
-}
-
-.avatar-wrapper {
-  border: none;
-
-  &, img {
-    @include border-radius-all(0);
-  }
-}

--- a/assets/stylesheets/desktop/topic-post.scss
+++ b/assets/stylesheets/desktop/topic-post.scss
@@ -102,23 +102,6 @@ nav.post-controls {
     margin-bottom: 10px;
   }
 
-  .avatars {
-    > div {
-      margin-top: 7px;
-
-      .poster {
-        margin-right: 6px;
-        position: relative;
-      }
-    }
-
-    .post-count {
-      @include border-radius-all(50%);
-      right: 7px;
-      top: 1px;
-    }
-  }
-
   .map {
     li {
       padding: 15px 15px;


### PR DESCRIPTION
Remove avatar logic from stylesheets so they are utilizing the discourse default (makes avatars consistently round everywhere)