### PR TITLE
Fix badge notification position

### DIFF
--- a/assets/stylesheets/common/base/header.scss
+++ b/assets/stylesheets/common/base/header.scss
@@ -71,6 +71,10 @@
         color: #000;
       }
     }
+
+    .badge-notification {
+      top: 0px;
+    }
   }
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/hu9LFnvK/137-standardise-logomark-across-properties

Fix the notification count position.

Before:
![screen shot 2015-11-11 at 1 23 08 pm](https://cloud.githubusercontent.com/assets/11432758/11082442/38e8f438-8879-11e5-8621-5f840e36b62d.png)

After:
![screen shot 2015-11-11 at 1 22 55 pm](https://cloud.githubusercontent.com/assets/11432758/11082443/3bf62394-8879-11e5-826d-b9b8eee0c035.png)
