### PR TITLE
Add sso-sign-up-btn widget

### DIFF
--- a/assets/javascripts/discourse/widgets/header.js.es6
+++ b/assets/javascripts/discourse/widgets/header.js.es6
@@ -121,6 +121,23 @@ createWidget('header-icons', {
   },
 });
 
+createWidget('sso-sign-up-btn', {
+  tagName: 'button.btn-primary.btn-small.sign-up-button',
+
+  click() {
+    $.cookie("sso_event", "sign_up", {
+      path: "/",
+      expires: 1
+    });
+    this.sendWidgetAction("showLogin")
+  },
+
+  html() {
+    return I18n.t("sign_up")
+  }
+
+});
+
 createWidget('header-buttons', {
   // SP START
   tagName: 'div.header-buttons',
@@ -137,6 +154,9 @@ createWidget('header-buttons', {
                                            action: "showCreateAccount" }));
     }
 
+    if(this.siteSettings.enable_sso) {
+      buttons.push(this.attach('sso-sign-up-btn'));
+    }
 
     buttons.push(this.attach('button', { label: 'log_in',
                                          className: 'btn-primary btn-small login-button',


### PR DESCRIPTION
When sso is enabled in Discourse - the sign-up button is removed completely. We can only define a single sso url (i.e. sitepoint.com/premium/community/sso) and can't set custom params on the fly without modifying the discourse core.

This basically wraps the sign-up button in a widget which sets the `sso_event` cookie before sending the `showLogin` action. We then use this in our premium `sso_controller` to decide where to redirect the user.

In premium...

```ruby
# sso_controller.rb

      if read_sso_event == "sign_up"
        redirect_to new_user_registration_path(params)
      else
        redirect_to new_user_session_path(params)
      end
```

```ruby
# concerns/sso.rb

  def read_sso_event
    cookies.delete :sso_event
  end
```
