### PR TITLE
Add new maestro outlets for bsa native ads

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-theme.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-theme.js.es6
@@ -1,0 +1,10 @@
+export default {
+  name: 'discourse-theme',
+  initialize() {
+
+    Ember.Handlebars.helper('fifthOrLast', function(index, total, options) {
+      return index === 4 || (index < 4 && index + 1 === total);
+    });
+
+  }
+};

--- a/assets/javascripts/discourse/templates/components/topic-list.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-list.hbs
@@ -1,0 +1,38 @@
+{{#unless skipHeader}}
+  <thead>
+    {{raw "topic-list-header" currentUser=currentUser
+                              canBulkSelect=canBulkSelect
+                              toggleInTitle=toggleInTitle
+                              hideCategory=hideCategory
+                              showPosters=showPosters
+                              showLikes=showLikes
+                              showOpLikes=showOpLikes
+                              showParticipants=showParticipants
+                              order=order
+                              ascending=ascending
+                              sortable=sortable
+                              bulkSelectEnabled=bulkSelectEnabled}}
+  </thead>
+{{/unless}}
+<tbody>
+  {{#each topics as |topic index|}}
+    {{topic-list-item topic=topic
+                      bulkSelectEnabled=bulkSelectEnabled
+                      showTopicPostBadges=showTopicPostBadges
+                      hideCategory=hideCategory
+                      showPosters=showPosters
+                      showParticipants=showParticipants
+                      showLikes=showLikes
+                      showOpLikes=showOpLikes
+                      expandGloballyPinned=expandGloballyPinned
+                      expandAllPinned=expandAllPinned
+                      selected=selected}}
+    {{#if (fifthOrLast index topics.length)}}
+      <tr>
+        <td colspan="6">
+          {{maestro-outlet templateAlias="Forums Home After Fifth Topic"}}
+        </td>
+      </tr>
+    {{/if}}
+  {{/each}}
+</tbody>

--- a/assets/javascripts/discourse/templates/connectors/topic-above-suggested/maestro.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-suggested/maestro.hbs
@@ -1,0 +1,1 @@
+{{maestro-outlet templateAlias="Forums Topic Above Suggested"}}


### PR DESCRIPTION
Trello: https://trello.com/c/Ez06uw2U/93-bsa-ads

Adds a custom handlerbars helper `fifthOrLast`.
Customizes `topic-list.hbs` to insert maestro outlet after fifth or last topic.

Adds maestro outlet to `topic-above-suggested` outlet.

These new outlets allow BSA ads to be inserted as maestro outlets

Homepage
![screen shot 2016-09-15 at 9 00 10 am](https://cloud.githubusercontent.com/assets/1479712/18534198/0bed138c-7b2c-11e6-82cc-77645143a717.png)

Topic page
![screen shot 2016-09-15 at 9 00 58 am](https://cloud.githubusercontent.com/assets/1479712/18534195/0a84e524-7b2c-11e6-83d8-431530119b4e.png)
