### PR TITLE
Track log out timestamps

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -12,6 +12,12 @@
 
 after_initialize do
 
+  # Track log-out timestamps
+  DiscourseEvent.on(:user_logged_out) do |user|
+    user.custom_fields["last_logged_out_at"] = Time.now
+    user.save
+  end
+
   module SitepointDesign
     class Engine < ::Rails::Engine
       engine_name "sitepoint_design"


### PR DESCRIPTION
If we ever need it - we can query users by last log out timestamp (maybe useful for support). The event is fired before the discourse session is destroyed and the user redirected to the custom logout url.

Would have used a web-hook https://meta.discourse.org/t/setting-up-webhooks/49045 but they only support topic/post events atm.