### PR TITLE
Add Podcast to nav, remove Shop, Versioning, Reference

### DIFF
--- a/assets/javascripts/discourse/templates/header.hbs
+++ b/assets/javascripts/discourse/templates/header.hbs
@@ -88,9 +88,7 @@
       {{header-extra-info topic=topic}}
     {{else}}
       <div class="header-links-wrapper clearfix">
-        <a class="header-link" target="_blank" href="https://shop.sitepoint.com" tabindex="2">Shop</a>
-        <a class="header-link" target="_blank" href="/versioning" tabindex="3">Versioning</a>
-        <a class="header-link" target="_blank" href="/reference" tabindex="4">Reference</a>
+        <a class="header-link" target="_blank" href="/versioning-show" tabindex="2">Podcast</a>
         <a class="header-link" target="_blank" href="/" tabindex="5">Articles</a>
         <a class="header-link u-button" target="_blank" href="/premium/topics/all?utm_source=sitepoint&utm_medium=link&utm_content=top-nav" tabindex="6">Premium</a>
       </div>

--- a/assets/javascripts/discourse/widgets/header.js.es6
+++ b/assets/javascripts/discourse/widgets/header.js.es6
@@ -175,23 +175,9 @@ createWidget('sitepoint-links', {
 
     links.push(h('a.header-link', {
       target: '_blank'  ,
-      href: 'https://shop.sitepoint.com'
+      href: '/versioning-show'
     },
-    'Shop' ));
-
-    links.push(h('a.header-link', {
-      target: '_blank',
-      href: '/versioning'
-    },
-    'Versioning'
-    ));
-
-    links.push(h('a.header-link', {
-      target: '_blank',
-      href: '/reference'
-    },
-    'Reference'
-    ));
+    'Podcast' ));
 
     links.push(h('a.header-link', {
       target: '_blank',

--- a/plugin.rb
+++ b/plugin.rb
@@ -44,9 +44,7 @@ after_initialize do
   # SP customisation: add SiteCustomization to add in crawler links
   header = <<-EOS.strip_heredoc.chomp
     <noscript>
-      <a class="header-link" href="https://shop.sitepoint.com" tabindex="2">Shop</a>
-      <a class="header-link" href="/versioning" tabindex="3">Versioning</a>
-      <a class="header-link" href="/reference" tabindex="4">Reference</a>
+      <a class="header-link" href="/versioning-show" tabindex="2">Podcast</a>
       <a class="header-link" href="/" tabindex="5">Articles</a>
       <a class="header-link u-button" target="_blank" href="/premium/topics/all?utm_source=sitepoint&utm_medium=link&utm_content=top-nav" tabindex="6">Premium</a>
     </noscript>


### PR DESCRIPTION
Trello: https://trello.com/c/gKK85u9B/694-add-podcast-landing-page-to-navigation

Adds Podcast link to nav
Removes Shop, Versioning and Reference links

![screen shot 2016-11-08 at 12 00 19 pm](https://cloud.githubusercontent.com/assets/11432758/20082602/46edbf1e-a5ab-11e6-9e33-88f3155ca464.png)
