### PR TITLE
Fix long category names in dropdown on Navigation

### DIFF
--- a/assets/stylesheets/common/base/topic-list.scss
+++ b/assets/stylesheets/common/base/topic-list.scss
@@ -65,7 +65,7 @@
     line-height: 1.5;
     margin-top: 5px;
     margin-right: 5px;
-    display: inline-block;
+    display: inline-flex;
 }
 
 // =================FIX HAMBURGER MENU AND USER IMAGE============================


### PR DESCRIPTION
As discussed at
https://www.sitepoint.com/community/t/off-the-fork-issues/301997/90?u=cpradio

I'm currently overriding it in a customization (Overrides to Plugin Theme component) on the forum to make it appear correctly.