### PR TITLE
Fix long category names in dropdown on Navigation

### DIFF
--- a/assets/stylesheets/common/components/badges.css.scss
+++ b/assets/stylesheets/common/components/badges.css.scss
@@ -6,6 +6,10 @@
   border-radius: 0 $border-radius-default-SP $border-radius-default-SP 0;
 }
 
+.list-controls .category-breadcrumb .badge-wrapper.box {
+  display: inline-flex;
+}
+
 .badge-wrapper.box span.badge-category {
   padding: 0 5px;
 }


### PR DESCRIPTION
As discussed at
https://www.sitepoint.com/community/t/off-the-fork-issues/301997/90?u=cpradio

I'm currently overriding it in a customization (Overrides to Plugin Theme component) on the forum to make it appear correctly.