### PR TITLE
Reference Font Awesome 5 SVG icon

### DIFF
--- a/assets/stylesheets/common/base/topic-list.scss
+++ b/assets/stylesheets/common/base/topic-list.scss
@@ -49,10 +49,8 @@
 }
 
 .discourse-tags:before, .list-tags a.discourse-tag:first-child:before {
-  font-family: 'FontAwesome';
-  content: "\F02C";
-  color: #919191;
-  vertical-align: top;
+  content: svg-uri('<svg fill="#919191" aria-hidden="true" data-prefix="fas" data-icon="tag" class="svg-inline--fa fa-tag fa-w-16" role="img" height=".7em" width=".7em" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M0 252.118V48C0 21.49 21.49 0 48 0h204.118a48 48 0 0 1 33.941 14.059l211.882 211.882c18.745 18.745 18.745 49.137 0 67.882L293.823 497.941c-18.745 18.745-49.137 18.745-67.882 0L14.059 286.059A48 48 0 0 1 0 252.118zM112 64c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48z"></path></svg>');
+  vertical-align: middle;
 }
 
 // ==================FIX CATEGORY BADGES===========================


### PR DESCRIPTION
Font Awesome 5 Correction

Once this is merged and deployed, the Component Header CSS Fix can have the block referenced removed from it.

```
/* remove this when PR #103 is applied */
.discourse-tags:before, .list-tags a.discourse-tag:first-child:before {
    content: svg-uri('<svg fill="#919191" aria-hidden="true" data-prefix="fas" data-icon="tag" class="svg-inline--fa fa-tag fa-w-16" role="img" height=".7em" width=".7em" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M0 252.118V48C0 21.49 21.49 0 48 0h204.118a48 48 0 0 1 33.941 14.059l211.882 211.882c18.745 18.745 18.745 49.137 0 67.882L293.823 497.941c-18.745 18.745-49.137 18.745-67.882 0L14.059 286.059A48 48 0 0 1 0 252.118zM112 64c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48z"></path></svg>');
    vertical-align: middle;
}
/* end PR #103 */
```