### PR TITLE
Update translation key for the Edit Category Button

### DIFF
--- a/assets/javascripts/discourse/templates/components/d-navigation.hbs
+++ b/assets/javascripts/discourse/templates/components/d-navigation.hbs
@@ -26,5 +26,5 @@
     class="btn-default edit-category"
     action=editCategory
     icon="wrench"
-    label="category.edit_long"}}
+    label="category.edit"}}
 {{/if}}


### PR DESCRIPTION
https://meta.discourse.org/t/translation-missing/112092/2?u=cpradio
https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/templates/components/d-navigation.hbs#L27